### PR TITLE
Add a renderer for null values

### DIFF
--- a/src/SellerLabs/Nucleus/View/Node.php
+++ b/src/SellerLabs/Nucleus/View/Node.php
@@ -177,6 +177,8 @@ class Node extends BaseObject implements
                     throw new NodeChildRenderingException($child);
                 })
                 ->join();
+        } else if ($this->content === null) {
+            return 'null';
         }
 
         throw new NodeRenderingException($this->content);


### PR DESCRIPTION
### Description

Adds a view renderer for null values.
### Why?

If a null value gets passed into a view, currently the stack trace is almost impossible to reason through; I was working with a view with a few (6 or 7) separate chunks of data to be rendered, and couldn't find the source of the issue. This makes it easier to see which things are not being passed into the view properly.
