### PR TITLE
Changes Reserved Iterable name to IterableType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
 - 7.0
 - 7.1
 - hhvm
+branches:
+  only:
+    - master
 before_script:
 - composer self-update
 - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "hhvm" -o "$TRAVIS_PHP_VERSION" = "hhvm-nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - 5.6
 - 7.0
+- 7.1
 - hhvm
 before_script:
 - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     }
   },
   "require": {
-    "lstrojny/phpunit-function-mocker": "0.2.*"
+    "lstrojny/phpunit-function-mocker": "0.4.*"
   }
 }

--- a/src/SellerLabs/Nucleus/Data/Collection.php
+++ b/src/SellerLabs/Nucleus/Data/Collection.php
@@ -8,7 +8,7 @@ namespace SellerLabs\Nucleus\Data;
  * @author Eduardo Trujillo <ed@sellerlabs.com>
  * @package SellerLabs\Nucleus\Data
  */
-abstract class Collection extends Iterable
+abstract class Collection extends IterableType
 {
     //
 }

--- a/src/SellerLabs/Nucleus/Data/IterableType.php
+++ b/src/SellerLabs/Nucleus/Data/IterableType.php
@@ -13,12 +13,12 @@ use SellerLabs\Nucleus\Foundation\Interfaces\ArrayableInterface;
 use SellerLabs\Nucleus\Meditation\Constraints\AbstractTypeConstraint;
 
 /**
- * Class Iterable.
+ * Class IterableType.
  *
  * @author Eduardo Trujillo <ed@sellerlabs.com>
  * @package SellerLabs\Nucleus\Data
  */
-abstract class Iterable extends BaseObject implements
+abstract class IterableType extends BaseObject implements
     ArrayableInterface,
     FunctorInterface,
     FoldableInterface,
@@ -82,14 +82,14 @@ abstract class Iterable extends BaseObject implements
     }
 
     /**
-     * @param array|Iterable $searchKeyPath
+     * @param array|IterableType $searchKeyPath
      *
      * @return Maybe
      */
     abstract public function lookupIn($searchKeyPath);
 
     /**
-     * @param array|Iterable $searchKeyPath
+     * @param array|IterableType $searchKeyPath
      *
      * @return mixed
      */
@@ -103,14 +103,14 @@ abstract class Iterable extends BaseObject implements
     /**
      * @param callable $callable
      *
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function fmap(callable $callable);
 
     /**
      * @param callable $callable
      *
-     * @return static|Iterable
+     * @return static|IterableType
      */
     public function map(callable $callable)
     {
@@ -120,14 +120,14 @@ abstract class Iterable extends BaseObject implements
     /**
      * @param callable $callable
      *
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function filter(callable $callable);
 
     /**
      * @param callable $callable
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function filterNot(callable $callable)
     {
@@ -139,14 +139,14 @@ abstract class Iterable extends BaseObject implements
     }
 
     /**
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function reverse();
 
     /**
      * @param callable $comparator
      *
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function sort(callable $comparator = null);
 
@@ -154,7 +154,7 @@ abstract class Iterable extends BaseObject implements
      * @param callable $comparatorValueMapper
      * @param callable|null $comparator
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function sortBy(
         callable $comparatorValueMapper,
@@ -174,12 +174,12 @@ abstract class Iterable extends BaseObject implements
      * @param int $begin
      * @param int|null $end
      *
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function slice($begin, $end = null);
 
     /**
-     * @return Iterable
+     * @return IterableType
      */
     public function tail()
     {
@@ -187,7 +187,7 @@ abstract class Iterable extends BaseObject implements
     }
 
     /**
-     * @return Iterable
+     * @return IterableType
      */
     public function init()
     {
@@ -197,7 +197,7 @@ abstract class Iterable extends BaseObject implements
     /**
      * @param int $amount
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function take($amount)
     {
@@ -212,7 +212,7 @@ abstract class Iterable extends BaseObject implements
     /**
      * @param int $amount
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function takeLast($amount)
     {
@@ -222,14 +222,14 @@ abstract class Iterable extends BaseObject implements
     /**
      * @param callable $predicate
      *
-     * @return Iterable
+     * @return IterableType
      */
     abstract public function takeWhile(callable $predicate);
 
     /**
      * @param callable $predicate
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function takeUntil(callable $predicate)
     {

--- a/src/SellerLabs/Nucleus/Data/Traits/ArrayBackingTrait.php
+++ b/src/SellerLabs/Nucleus/Data/Traits/ArrayBackingTrait.php
@@ -8,7 +8,7 @@ use SellerLabs\Nucleus\Data\ArrayList;
 use SellerLabs\Nucleus\Data\Interfaces\FunctorInterface;
 use SellerLabs\Nucleus\Data\Interfaces\ListInterface;
 use SellerLabs\Nucleus\Data\Interfaces\MonoidInterface;
-use SellerLabs\Nucleus\Data\Iterable;
+use SellerLabs\Nucleus\Data\IterableType;
 use SellerLabs\Nucleus\Exceptions\CoreException;
 use SellerLabs\Nucleus\Exceptions\MindTheGapException;
 use SellerLabs\Nucleus\Meditation\Arguments;
@@ -130,7 +130,7 @@ trait ArrayBackingTrait
      * @param int $begin
      * @param int $end
      *
-     * @return Iterable
+     * @return IterableType
      * @throws CoreException
      * @throws InvalidArgumentException
      */
@@ -174,7 +174,7 @@ trait ArrayBackingTrait
     /**
      * @param callable $predicate
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function takeWhile(callable $predicate)
     {
@@ -250,7 +250,7 @@ trait ArrayBackingTrait
     }
 
     /**
-     * @param array|Iterable $searchKeyPath
+     * @param array|IterableType $searchKeyPath
      *
      * @return Maybe
      */
@@ -274,7 +274,7 @@ trait ArrayBackingTrait
 
         $innerValue = Maybe::fromJust($value);
 
-        if ($innerValue instanceof Iterable) {
+        if ($innerValue instanceof IterableType) {
             return $innerValue->lookupIn($path->tail());
         }
 
@@ -282,7 +282,7 @@ trait ArrayBackingTrait
     }
 
     /**
-     * @param array|Iterable $searchKeyPath
+     * @param array|IterableType $searchKeyPath
      *
      * @return bool
      * @throws MindTheGapException
@@ -305,7 +305,7 @@ trait ArrayBackingTrait
 
         $innerValue = Maybe::fromJust($this->lookup($path->head()));
 
-        if ($innerValue instanceof Iterable) {
+        if ($innerValue instanceof IterableType) {
             return $innerValue->memberIn($path->tail());
         }
 
@@ -315,7 +315,7 @@ trait ArrayBackingTrait
     /**
      * @param callable $comparator
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function sort(callable $comparator = null)
     {
@@ -372,7 +372,7 @@ trait ArrayBackingTrait
      *
      * @param array $excluded
      *
-     * @return static|Iterable
+     * @return static|IterableType
      * @throws InvalidArgumentException
      */
     public function exceptValues($excluded = [])

--- a/src/SellerLabs/Nucleus/Meditation/Spec.php
+++ b/src/SellerLabs/Nucleus/Meditation/Spec.php
@@ -13,7 +13,7 @@ use SellerLabs\Nucleus\Control\Maybe;
 use SellerLabs\Nucleus\Data\ArrayList;
 use SellerLabs\Nucleus\Data\ArrayMap;
 use SellerLabs\Nucleus\Data\Interfaces\LeftKeyFoldableInterface;
-use SellerLabs\Nucleus\Data\Iterable;
+use SellerLabs\Nucleus\Data\IterableType;
 use SellerLabs\Nucleus\Exceptions\CoreException;
 use SellerLabs\Nucleus\Foundation\BaseObject;
 use SellerLabs\Nucleus\Meditation\Constraints\AbstractConstraint;
@@ -240,7 +240,7 @@ class Spec extends BaseObject implements CheckableInterface
      *
      * @param string $fieldName
      *
-     * @return Iterable
+     * @return IterableType
      */
     protected function getInternalFieldConstraints($fieldName)
     {
@@ -252,7 +252,7 @@ class Spec extends BaseObject implements CheckableInterface
      *
      * @param string $fieldName
      *
-     * @return Iterable
+     * @return IterableType
      */
     public function getFieldConstraints($fieldName)
     {
@@ -268,7 +268,7 @@ class Spec extends BaseObject implements CheckableInterface
 
         if (is_array($constraints)) {
             return ArrayList::of($constraints);
-        } elseif ($constraints instanceof Iterable) {
+        } elseif ($constraints instanceof IterableType) {
             return $constraints;
         }
 
@@ -400,7 +400,7 @@ class Spec extends BaseObject implements CheckableInterface
      * Set the constraints for a field.
      *
      * @param string $fieldName
-     * @param Iterable|array|AbstractConstraint $constraints
+     * @param IterableType|array|AbstractConstraint $constraints
      *
      * @return static
      */

--- a/src/SellerLabs/Nucleus/Meditation/TypedSpec.php
+++ b/src/SellerLabs/Nucleus/Meditation/TypedSpec.php
@@ -5,7 +5,7 @@ namespace SellerLabs\Nucleus\Meditation;
 use SellerLabs\Nucleus\Control\Maybe;
 use SellerLabs\Nucleus\Data\ArrayList;
 use SellerLabs\Nucleus\Data\ArrayMap;
-use SellerLabs\Nucleus\Data\Iterable;
+use SellerLabs\Nucleus\Data\IterableType;
 use SellerLabs\Nucleus\Meditation\Constraints\AbstractTypeConstraint;
 
 /**
@@ -50,7 +50,7 @@ class TypedSpec extends Spec
      *
      * @param string $fieldName
      *
-     * @return Iterable
+     * @return IterableType
      */
     protected function getInternalFieldConstraints($fieldName)
     {


### PR DESCRIPTION
Library breaks in 7.1 due to Iterable being reserved name.